### PR TITLE
fix: allow null value in updateSetting for currency preference

### DIFF
--- a/app/src/main/kotlin/com/titan2keyboard/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/titan2keyboard/data/repository/SettingsRepositoryImpl.kt
@@ -38,7 +38,7 @@ class SettingsRepositoryImpl @Inject constructor(
             )
         }
 
-    override suspend fun updateSetting(key: String, value: Any) {
+    override suspend fun updateSetting(key: String, value: Any?) {
         dataStore.edit { preferences ->
             when (key) {
                 "autoCapitalize" -> preferences[PreferencesKeys.AUTO_CAPITALIZE] = value as Boolean

--- a/app/src/main/kotlin/com/titan2keyboard/domain/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/titan2keyboard/domain/repository/SettingsRepository.kt
@@ -17,7 +17,7 @@ interface SettingsRepository {
      * @param key The setting key
      * @param value The new value
      */
-    suspend fun updateSetting(key: String, value: Any)
+    suspend fun updateSetting(key: String, value: Any?)
 
     /**
      * Reset all settings to defaults


### PR DESCRIPTION
Update SettingsRepository interface and implementation to accept Any?
instead of Any, allowing null to be passed through for the preferred
currency setting. This enables the "Auto (locale default)" option to
work correctly by removing the preference from DataStore.